### PR TITLE
adding space between Copyright2021 part and the @amupedia.com

### DIFF
--- a/components/common/Footer.js
+++ b/components/common/Footer.js
@@ -74,7 +74,7 @@ const Footer = () => {
         </p>
       </div>
       <div id={styles.ftbg}>
-        <p>Copyright2021@amupedia.com</p>
+        <p>Copyright2021  @amupedia.com</p>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Description

I have solved the issue "Make the Footer more Attractive" #100. I added two spaces between Copyright2021 part and the @amupedia.com in the Footer.

## Pull Request Checklist

Please make sure that your PR meets the following requirements:

- [ ✓] The app is working correctly after applying the changes.
- [ ✓] The app is responsive and displays properly on different screen sizes and devices.
- [ ✓] The changes are thoroughly documented in the appropriate files or documentation sections.
- [ ✓] The coding conventions and style guidelines are followed consistently.

## Checklist

Please check all applicable boxes and provide any additional information if needed.

- [ ✓] I have tested the changes locally and ensured that the app is functioning as expected.
- [ ✓] I have verified that the app is responsive and looks good on various screen sizes and devices.
- [ ✓] I have reviewed the documentation and ensured that it accurately reflects the changes made.
- [ ✓] I have followed the coding conventions and style guidelines defined in the project.
- [ ✓] I have run the automated tests and all of them pass.
- [ ✓] I have considered the performance implications of the changes made.
- [ ✓] I have considered the security implications of the changes made.
- [ ✓] I have checked for any potential regressions or side effects caused by the changes.
- [ ✓] I have performed a self-review of my code.
- [ ✓] Starred the repository.
- [ ] Added My Name to the Contributor's List.
- [ ✓] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [ ✓] I ran the app and tested it locally to verify that it works as expected.

![image](https://github.com/amupedia2021/Project-Amupedia/assets/103322943/5bd70aa7-a4c0-40e7-ae95-686fbe3ea245)
