### PR TITLE
fix: In the homepage navbar, contact us redirect is fixed

### DIFF
--- a/components/common/Navbar.js
+++ b/components/common/Navbar.js
@@ -356,7 +356,7 @@ const Navbar = () => {
               onClick={() => {
                 router.push('/');
                 setTimeout(() => {
-                  const contacts = document.getElementById('contactus');
+                  const contacts = document.getElementById('contact_us');
                   if (contacts) contacts.scrollIntoView();
                   //onClick();
                 }, 10);

--- a/components/common/Navbar.js
+++ b/components/common/Navbar.js
@@ -361,7 +361,7 @@ const Navbar = () => {
                   //onClick();
                 }, 10);
               }}
-              className={`${styles.lnk} ${contactActive ? styles.active : ''} ${
+              className={`${styles.lnk} ${contactActive ? styles.active : ' '} ${
                 navbar && styles.nav_active 
               }`}
             >

--- a/components/common/Navbar.js
+++ b/components/common/Navbar.js
@@ -365,7 +365,7 @@ const Navbar = () => {
                 navbar && styles.nav_active
               }`}
             >
-              Contact Us
+              Contact Us 
             </a>
           </li>
         </ul>

--- a/components/common/Navbar.js
+++ b/components/common/Navbar.js
@@ -362,7 +362,7 @@ const Navbar = () => {
                 }, 10);
               }}
               className={`${styles.lnk} ${contactActive ? styles.active : ''} ${
-                navbar && styles.nav_active
+                navbar && styles.nav_active 
               }`}
             >
               Contact Us 

--- a/pages/index.js
+++ b/pages/index.js
@@ -245,8 +245,8 @@ export default function Home() {
           </div>
 
           {/* <!-- Contact Form  --> */}
-          <h2 id='contactus' className={styles.grabh2}>
-            Get In Touch With Us
+          <h2 id='contact_us' className={styles.grabh2}>
+            Get In Touch With Us 
           </h2>
           <form onSubmit={handleSubmit} aria-label='Contact form'>
             <div className={styles.cntfrm}>


### PR DESCRIPTION
## Description

The navbar has Contact us now on clicking on contact us it navigate in the form below 

Fixes #612 
 
## Checklist

- [ ] Added My Name to the Contributor's List.

# Screenshots - If Any (Optional)

![Screenshot 2024-01-10 003058](https://github.com/amupedia2021/amupedia-web/assets/114082380/a8911c80-6fce-459b-abf8-5ee0866f7ddc)

## Reproduction steps
   1. Go to 'https://www.amupedia.com/'
   2. Click on 'Contact Us'
   4. See error
